### PR TITLE
Update GitHub Actions runner to ubuntu-latest

### DIFF
--- a/.github/workflows/build-push-gcr.yaml
+++ b/.github/workflows/build-push-gcr.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   deploy-cloud-run:
     name: Deploy to Cloud Run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu-20.04 runner went away earlier this year